### PR TITLE
Make the step definitions glob pattern configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,34 @@ Plugin for [Vitest](https://vitest.dev/) to allow tests to be written in [Cucumb
 
 ## Installation
 
-```
-$ npm install --save-dev vitest-cucumber-plugin
+```bash
+npm install --save-dev vitest-cucumber-plugin
 ```
 
 ## Usage
 
-
 ### vite.config.js
 
-Import the plugin then add it to the plugins array.  Change test.inclue to look for .feature files.
+Import the plugin then add it to the plugins array.  Change `test.include` to look for `.feature` files.
 
-```
+```js
 import { defineConfig } from 'vitest/config'
 import vitestCucumberPlugin from 'vitest-cucumber-plugin';
 
+// Optional plugin configuration
+const options = {
+  stepDefinitionsPattern : 'features/**/*.js', // the default (relative to the Vite config root option)
+  tags : '<tags boolean expression>', // Use this to filter the test via boolean tags expression
+  log : { 
+    level : '<"fatal", "error", "warn", "info", "debug", "trace" or "silent">',
+    file : '<log path>', // Write the logs to a file instead of stdio (the default)
+  }
+}
+
 export default defineConfig({
-    plugins: [vitestCucumberPlugin()],
+    plugins: [vitestCucumberPlugin(options)],
     test: {
         include : [ '**/*.feature' ],
-        cucumber : {
-           tags : "<tags boolean expression>", // Use this to filter the test via boolean tags expression
-           log : { 
-              level : "<'fatal', 'error', 'warn', 'info', 'debug', 'trace' or 'silent'>",
-              file : "<log path>", // Write the logs to a file instead of stdio (the default)
-           }
-        }
     },
 })
 ```
@@ -39,7 +41,7 @@ the steps.  You can pipe the logs through pino-pretty to make them more human re
 
 ### Writing tests
 
-Put feature files into the 'features/' directory and step definitions into the 'features/step_definitions/' directory.
+Put feature files somewhere that matches your glob pattern in `test.include`. Step definitions are fetched from `features/**/*.js` by default, the pattern can be configured using the `stepDefinitionsPattern` option for the plugin function.
 
 See below for the differences between tests written for Cucumber and for this plugin.
 
@@ -61,7 +63,8 @@ second is an array of parameters values.  The third is a data table or a doc str
 return a new state object which is passed to the next step definition in the chain.
 
 For example, here is how you'd write step definitions in Cucumber:
-```
+
+```js
 const assert = require('assert');
 const { Given, When, Then } = require('@cucumber/cucumber');
 
@@ -87,7 +90,8 @@ Then('I should be told {string}', function (expectedAnswer, dataTable) {
 ```
 
 Here is how you'd write the same step functions in this plugin:
-```
+
+```js
 import { Given, When, Then } from 'vitest-cucumber-plugin';
 import _ from 'lodash/fp.js';
 import { expect } from 'vitest'

--- a/src/generate/feature.js
+++ b/src/generate/feature.js
@@ -4,7 +4,7 @@ import { generateExample, generateScenarioOutline, generateRule } from './index.
 import { escape, shouldSkip } from './util.js';
 import { glob } from 'glob';
 
-const findJsFiles = async () => glob('features/**/*.js');
+const findJsFiles = async (pattern, cwd) => glob(pattern, {cwd});
 
 export const generateFeature = async (config,feature) => {
     const name = feature.name;
@@ -35,7 +35,7 @@ export const generateFeature = async (config,feature) => {
         return imports+`
 import './${file}';`;
     };
-    const jsFiles = await findJsFiles();
+    const jsFiles = await findJsFiles(config.stepDefinitionsPattern, config.root);
     const jsFilesImport = _.reduce(jsFilesImportReducer,'',jsFiles);
 
     const code = `import { expect, test, describe, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';

--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,10 @@ import {
 
 const featureRegex = /\.feature$/;
 
-const compileFeatureToJS = async (config,featureSrc) => {
+const compileFeatureToJS = async (config, featurePath, featureSrc) => {
     const feature = parse(featureSrc);
 
-    const code = await generateFeature(config,feature);
+    const code = await generateFeature(config, featurePath, feature);
 
     return code;
 }
@@ -78,7 +78,7 @@ export default function vitestCucumberPlugin(options = {}) {
         },
         transform : async (src,id) => {
             if (featureRegex.test(id)) {
-                const code = await compileFeatureToJS(config,src);
+                const code = await compileFeatureToJS(config, id, src);
 
                 log.debug('transform '+id+' -> '+code);
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,14 +63,13 @@ export const DataTable = (dataTable) => {
     return _.map((row) => _.zipObject(parameters,row))(rows);
 }
 
-export default function vitestCucumberPlugin() {
+export default function vitestCucumberPlugin(options = {}) {
     let config;
     
     return {
         name : 'vitest-cucumber-transform',
         configResolved : (resolvedConfig) => {
-            config = _.defaults({ root : resolvedConfig.root, log : { level : 'warn' } },
-                                _.get('test.cucumber',resolvedConfig))
+            config = _.defaults({ root : resolvedConfig.root, stepDefinitionsPattern: 'features/**/*.js', log : { level : 'warn' } }, options)
             logConfig(config.log);
 
             config = _.set('tagsFunction',tagsFunction(_.get('tags',config)),config);

--- a/tests/background/vite.config.js
+++ b/tests/background/vite.config.js
@@ -4,10 +4,9 @@ import vitestCucumberPlugin from 'vitest-cucumber-plugin';
 export default defineConfig(({ mode }) => {
     const level = (mode === 'test-debug') ? 'debug' : 'warn';
     return {
-        plugins: [vitestCucumberPlugin()],
+        plugins: [vitestCucumberPlugin({ log : { level } })],
         test: {
             include : [ '**/*.feature' ],
-            cucumber : { log : { level } },
         },
     }
 });

--- a/tests/data-tables/vite.config.js
+++ b/tests/data-tables/vite.config.js
@@ -4,10 +4,9 @@ import vitestCucumberPlugin from 'vitest-cucumber-plugin';
 export default defineConfig(({ mode }) => {
     const level = (mode === 'test-debug') ? 'info' : 'warn';
     return {
-        plugins: [vitestCucumberPlugin()],
+        plugins: [vitestCucumberPlugin({ log : { level } })],
         test: {
             include : [ '**/*.feature' ],
-            cucumber : { log : { level } },
         },
     }
 });

--- a/tests/doc-strings/vite.config.js
+++ b/tests/doc-strings/vite.config.js
@@ -2,12 +2,11 @@ import { defineConfig } from 'vitest/config'
 import vitestCucumberPlugin from 'vitest-cucumber-plugin';
 
 export default defineConfig(({ mode }) => {
-    const logLevel = (mode === 'test-debug') ? 'info' : 'warn';
+    const level = (mode === 'test-debug') ? 'info' : 'warn';
     return {
-        plugins: [vitestCucumberPlugin()],
+        plugins: [vitestCucumberPlugin({ log: { level } })],
         test: {
             include : [ '**/*.feature' ],
-            cucumber : { logLevel },
         },
     }
 });

--- a/tests/hooks/vite.config.js
+++ b/tests/hooks/vite.config.js
@@ -4,10 +4,9 @@ import vitestCucumberPlugin from 'vitest-cucumber-plugin';
 export default defineConfig(({ mode }) => {
     const level = (mode === 'test-debug') ? 'info' : 'warn';
     return {
-        plugins: [vitestCucumberPlugin()],
+        plugins: [vitestCucumberPlugin({ log : { level } })],
         test: {
             include : [ '**/*.feature' ],
-            cucumber : { log : { level } },
         },
     }
 });

--- a/tests/is-it-friday/vite.config.js
+++ b/tests/is-it-friday/vite.config.js
@@ -4,10 +4,9 @@ import vitestCucumberPlugin from 'vitest-cucumber-plugin';
 export default defineConfig(({ mode }) => {
     const level = (mode === 'test-debug') ? 'info' : 'warn';
     return {
-        plugins: [vitestCucumberPlugin()],
+        plugins: [vitestCucumberPlugin({ log : { level } })],
         test: {
             include : [ '**/*.feature' ],
-            cucumber : { log : { level } },
         },
     }
 });

--- a/tests/tags/vite.config.js
+++ b/tests/tags/vite.config.js
@@ -2,11 +2,8 @@ import { defineConfig } from 'vitest/config'
 import vitestCucumberPlugin from 'vitest-cucumber-plugin';
 
 export default defineConfig({
-    plugins: [vitestCucumberPlugin()],
+    plugins: [vitestCucumberPlugin({ tags : "not (@skip or @yuck) or (@yuck and @goodstuff)" })],
     test: {
         include : [ '**/*.feature' ],
-        cucumber : {
-            tags : "not (@skip or @yuck) or (@yuck and @goodstuff)",
-        },
     },
 })

--- a/tests/vue/vite.config.js
+++ b/tests/vue/vite.config.js
@@ -5,10 +5,9 @@ import vue from '@vitejs/plugin-vue';
 export default defineConfig(({ mode }) => {
     const level = (mode === 'test-debug') ? 'debug' : 'warn';
     return {
-        plugins: [vue(),vitestCucumberPlugin()],
+        plugins: [vue(), vitestCucumberPlugin({ log : { level } })],
         test: {
             include : [ '**/*.feature' ],
-            cucumber : { log : { level } },
             environment : 'jsdom',
         },
     }


### PR DESCRIPTION
To be able to place my step definitions wherever I want (I have them in `**/*.steps.ts` files) I need the glob pattern for the step definition files to be configurable. This PR adds support for that.

BREAKING CHANGE: this PR also moves the plugin's configuration to be a parameter for the plugin function instead of being part of Vitest's `test` config, as the latter is much harder to add TypeScript types for in a good way (which I will follow up with once TS support is added/merged).